### PR TITLE
feat(console): add CLI command to clear expired sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,25 @@ Just call `login` on security user as you are used to:
 ```php
 $this->securityUser->login($email, $password);
 ```
+
+## Clearing expired sessions
+
+Register the extension, which registers the console command:
+
+```neon
+extensions:
+	doctrineAuthenticator: ADT\DoctrineAuthenticator\DI\DoctrineAuthenticatorExtension
+```
+
+It deletes sessions whose `validUntil` is older than the given number of days
+(defaults to 365 days, i.e. one year):
+
+```bash
+# delete sessions expired more than a year ago (default)
+php bin/console doctrine-authenticator:clear-expired-sessions
+
+# delete sessions expired more than 30 days ago
+php bin/console doctrine-authenticator:clear-expired-sessions 30
+```
+
+Run it periodically (e.g. via cron) to keep the `session` table clean.

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,11 @@
 		"php": ">=8.4",
 		"nette/security": "^3.2",
 		"nette/http": "^3.0",
+		"nette/di": "^3.1",
 		"doctrine/orm": "^2.9|^3.0",
 		"adt/doctrine-components": "^3.3",
-		"brick/phonenumber": "^0.7"
+		"brick/phonenumber": "^0.7",
+		"symfony/console": "^6.0|^7.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Console/ClearExpiredSessionsCommand.php
+++ b/src/Console/ClearExpiredSessionsCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ADT\DoctrineAuthenticator\Console;
+
+use ADT\DoctrineAuthenticator\StorageEntity;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'doctrine-authenticator:clear-expired-sessions', description: 'Delete expired sessions.')]
+class ClearExpiredSessionsCommand extends Command
+{
+	public function __construct(private readonly EntityManagerInterface $em)
+	{
+		parent::__construct();
+	}
+
+	protected function configure(): void
+	{
+		$this->addArgument(
+			'days',
+			InputArgument::OPTIONAL,
+			'Deletes sessions whose valid until date is older than the specified number of days.',
+			365
+		);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		$count = $this->em->createQueryBuilder()
+			->delete(StorageEntity::class, 'e')
+			->where('e.validUntil < :validUntil')
+			->setParameter('validUntil', new DateTimeImmutable('-' . (int) $input->getArgument('days') . ' days'))
+			->getQuery()
+			->execute();
+
+		return self::SUCCESS;
+	}
+}

--- a/src/DI/DoctrineAuthenticatorExtension.php
+++ b/src/DI/DoctrineAuthenticatorExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ADT\DoctrineAuthenticator\DI;
+
+use ADT\DoctrineAuthenticator\Console\ClearExpiredSessionsCommand;
+use Nette\DI\CompilerExtension;
+
+/** @noinspection PhpUnused */
+class DoctrineAuthenticatorExtension extends CompilerExtension
+{
+	public function loadConfiguration(): void
+	{
+		$builder = $this->getContainerBuilder();
+
+		// command registration
+
+		$builder->addDefinition($this->prefix('clearExpiredSessionsCommand'))
+			->setFactory(ClearExpiredSessionsCommand::class)
+			->setAutowired(false);
+	}
+}


### PR DESCRIPTION
- Add ClearExpiredSessionsCommand with configurable days threshold (default 365)
- Register DoctrineAuthenticatorExtension for Nette DI to auto-wire the command
- Add symfony/console and nette/di as required dependencies
- Document extension registration and command usage in README